### PR TITLE
Biology menu

### DIFF
--- a/src/simulation/SimulationData.cpp
+++ b/src/simulation/SimulationData.cpp
@@ -87,6 +87,7 @@ std::vector<menu_section> LoadMenus()
 		{0xE044, String("Liquids"), 0, 1},
 		{0xE050, String("Powders"), 0, 1},
 		{0xE051, String("Solids"), 0, 1},
+		{0xE046, String("Biological"), 0, 1},
 		{0xE046, String("Radioactive"), 0, 1},
 		{0xE04C, String("Special"), 0, 1},
 		{0xE052, String("Game Of Life"), 0, 1},

--- a/src/simulation/SimulationData.h
+++ b/src/simulation/SimulationData.h
@@ -15,15 +15,16 @@
 #define SC_LIQUID 7
 #define SC_POWDERS 8
 #define SC_SOLIDS 9
-#define SC_NUCLEAR 10
-#define SC_SPECIAL 11
-#define SC_LIFE 12
-#define SC_TOOL 13
-#define SC_FAVORITES 14
-#define SC_DECO 15
-#define SC_CRACKER 16
-#define SC_CRACKER2 17
-#define SC_TOTAL 16
+#define SC_BIOLOGICAL 10
+#define SC_NUCLEAR 11
+#define SC_SPECIAL 12
+#define SC_LIFE 13
+#define SC_TOOL 14
+#define SC_FAVORITES 15
+#define SC_DECO 16
+#define SC_CRACKER 17
+#define SC_CRACKER2 18
+#define SC_TOTAL 17
 
 #define O_WL_WALLELEC	122
 #define O_WL_EWALL		123

--- a/src/simulation/elements/BLD.cpp
+++ b/src/simulation/elements/BLD.cpp
@@ -9,7 +9,7 @@ void Element::Element_BLD()
 	Name = "BLD";
 	Colour = PIXPACK(0x990000);
 	MenuVisible = 1;
-	MenuSection = SC_LIQUID;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.6f;

--- a/src/simulation/elements/DT.cpp
+++ b/src/simulation/elements/DT.cpp
@@ -6,7 +6,7 @@ void Element::Element_DT()
 	Name = "DT";
 	Colour = PIXPACK(0x554040);
 	MenuVisible = 1;
-	MenuSection = SC_POWDERS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.7f;

--- a/src/simulation/elements/LUNG.cpp
+++ b/src/simulation/elements/LUNG.cpp
@@ -9,7 +9,7 @@ void Element::Element_LUNG()
 	Name = "LUNG";
 	Colour = PIXPACK(0x990066);
 	MenuVisible = 1;
-	MenuSection = SC_SOLIDS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.0f;

--- a/src/simulation/elements/MEAT.cpp
+++ b/src/simulation/elements/MEAT.cpp
@@ -9,7 +9,7 @@ void Element::Element_MEAT()
 	Name = "MEAT";
 	Colour = PIXPACK(0x990022);
 	MenuVisible = 1;
-	MenuSection = SC_SOLIDS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.0f;

--- a/src/simulation/elements/PLNT.cpp
+++ b/src/simulation/elements/PLNT.cpp
@@ -10,7 +10,7 @@ void Element::Element_PLNT()
 	Name = "PLNT";
 	Colour = PIXPACK(0x0CAC00);
 	MenuVisible = 1;
-	MenuSection = SC_SOLIDS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.0f;

--- a/src/simulation/elements/VINE.cpp
+++ b/src/simulation/elements/VINE.cpp
@@ -10,7 +10,7 @@ void Element::Element_VINE()
 	Name = "VINE";
 	Colour = PIXPACK(0x079A00);
 	MenuVisible = 1;
-	MenuSection = SC_SOLIDS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.0f;

--- a/src/simulation/elements/VIRS.cpp
+++ b/src/simulation/elements/VIRS.cpp
@@ -9,7 +9,7 @@ void Element::Element_VIRS()
 	Name = "VIRS";
 	Colour = PIXPACK(0xFE11F6);
 	MenuVisible = 1;
-	MenuSection = SC_LIQUID;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.6f;

--- a/src/simulation/elements/VRSG.cpp
+++ b/src/simulation/elements/VRSG.cpp
@@ -9,7 +9,7 @@ void Element::Element_VRSG()
 	Name = "VRSG";
 	Colour = PIXPACK(0xFE68FE);
 	MenuVisible = 0;
-	MenuSection = SC_GAS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 1.0f;

--- a/src/simulation/elements/VRSS.cpp
+++ b/src/simulation/elements/VRSS.cpp
@@ -9,7 +9,7 @@ void Element::Element_VRSS()
 	Name = "VRSS";
 	Colour = PIXPACK(0xD408CD);
 	MenuVisible = 0;
-	MenuSection = SC_SOLIDS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.0f;

--- a/src/simulation/elements/WOOD.cpp
+++ b/src/simulation/elements/WOOD.cpp
@@ -10,7 +10,7 @@ void Element::Element_WOOD()
 	Name = "WOOD";
 	Colour = PIXPACK(0xC0A040);
 	MenuVisible = 1;
-	MenuSection = SC_SOLIDS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.0f;

--- a/src/simulation/elements/YEST.cpp
+++ b/src/simulation/elements/YEST.cpp
@@ -8,7 +8,7 @@ void Element::Element_YEST()
 	Name = "YEST";
 	Colour = PIXPACK(0xEEE0C0);
 	MenuVisible = 1;
-	MenuSection = SC_POWDERS;
+	MenuSection = SC_BIOLOGICAL;
 	Enabled = 1;
 
 	Advection = 0.7f;


### PR DESCRIPTION
Moved the modded elements MEAT, LUNG, DT, BLD and the vanilla elements VIRS, VRSS, VRSG, VINE, YEST, PLNT, WOOD into a new Biological category of elements.

I'm not sure how to edit the icon, so I copied the radioactive symbol as it looks similar to a biohazard symbol.