### PR TITLE
Recap WBLD and BLD

### DIFF
--- a/src/simulation/elements/BLD.cpp
+++ b/src/simulation/elements/BLD.cpp
@@ -46,6 +46,10 @@ void Element::Element_BLD()
 
 	Update = &update;
 	Graphics = &graphics;
+	
+	Max_O2 = 200;
+	Max_CO2 = 100;
+	Max_Health = 500;
 }
 
 static int update(UPDATE_FUNC_ARGS)

--- a/src/simulation/elements/WBLD.cpp
+++ b/src/simulation/elements/WBLD.cpp
@@ -46,6 +46,10 @@ void Element::Element_WBLD()
 
 	Update = &update;
 	Graphics = &graphics;
+
+	Max_O2 = 100;
+	Max_CO2 = 100;
+	Max_Health = 200;
 }
 
 static int update(UPDATE_FUNC_ARGS)


### PR DESCRIPTION
Without Max_CO2, DoRespirationDamage will damage BLD and WBLD regardless of CO2 levels.
This Pull requests fixes the issue by adding Max_CO2 to these two elements.

Also adds Max_Health and Max_O2 to both, but you can change it if you'd like.